### PR TITLE
fix panic in decoder.decoderStateCleanup (freeing object already free)

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -141,7 +141,7 @@ func (d *Decoder) decoderStateCleanup() {
 	vorbis.InfoClear(&d.info)
 	d.info.Free()
 
-	vorbis.OggSyncDestroy(&d.syncState)
+	vorbis.OggSyncClear(&d.syncState)
 	d.syncState.Free()
 
 	// clear up all remaining refs


### PR DESCRIPTION
vorbis.OggSyncDestroy frees all memory allocated by d.syncState, causing the following d.syncState.Free() to panic.

Use vorbis.OggSyncClear, instead, following the pattern for all other allocated objects.